### PR TITLE
Add resize observer

### DIFF
--- a/3-mutation-observer/end/index.html
+++ b/3-mutation-observer/end/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Frontend System Design Fundamentals</title>
+    <link rel="stylesheet" href="../../styles/index.css">
+    <template id="card_template">
+        <article class="card">
+            <h3 class="card__title"></h3>
+            <div class="card__body">
+                <div class='card__body__image'></div>
+                <section class='card__body__content' contenteditable="true">
+                </section>
+            </div>
+        </article>
+    </template>
+</head>
+<body>
+<main id="container">
+    <div id="list"></div>
+    <div id="bottom-observer">
+        Bottom Observer
+    </div>
+</main>
+<script type="module">
+    import {createCardElement, getHeading} from "./utils.js";
+    import {initMockDB} from "../../utils/db.js";
+
+    const SUPPORTED_ELEMENTS = new Set([
+        '/h1',
+        '/h2',
+        '/h3'
+    ]);
+
+    const db = initMockDB({
+        title: "Fundamentals of Frontend System Design",
+        body: "Learning to use Intersection Observer"
+    });
+    const list = document.getElementById('list');
+    const observerElement = document.getElementById('bottom-observer');
+
+    const mutationObserver = new MutationObserver((mutations) => {
+        for (const {target, type} of mutations) {
+            if (
+                type === 'characterData' &&
+                SUPPORTED_ELEMENTS.has(target?.textContent)
+            ) {
+                const element = getHeading(target);
+                target.replaceWith(element);
+                element.focus();
+            }
+        }
+    })
+
+    let page = 0;
+    const observer = new IntersectionObserver(async ([bottom]) => {
+        if (bottom.isIntersecting) {
+            observerElement.textContent = "Loading";
+            const data = await db.getPage(page++);
+            const fragment = new DocumentFragment();
+            data.forEach(({title, body}) => {
+                const card = createCardElement(title, body);
+                fragment.appendChild(card);
+                const content = card.querySelector('.card__body__content');
+                mutationObserver.observe(content, { characterData: true, subtree: true})
+            });
+
+            list.appendChild(fragment);
+        }
+    }, {threshold: 0.1})
+    observer.observe(observerElement);
+</script>
+</body>
+</html>

--- a/3-mutation-observer/end/utils.js
+++ b/3-mutation-observer/end/utils.js
@@ -1,0 +1,23 @@
+export function createCardElement(title, body) {
+    const template = document.getElementById('card_template');
+    const element = template.content.cloneNode(true).firstElementChild;
+    const [cardTitle] = element.getElementsByTagName("h3");
+    const [cardBody] = element.getElementsByTagName("section");
+    [cardTitle.textContent, cardBody.textContent] = [title, body];
+    return element;
+}
+
+export function getHeading(node) {
+    let element = node;
+    if (node.textContent.startsWith("/h3")) {
+        element = document.createElement("h3");
+    } else if (node.textContent.startsWith("/h2")) {
+        element = document.createElement("h2");
+    } else if (node.textContent.startsWith("/h1")) {
+        element = document.createElement("h1");
+    }
+    element.textContent = node.textContent.slice(3);
+    element.setAttribute('contenteditable', "true");
+    element.textContent = element.textContent === '' ? "Heading" : element.textContent;
+    return element;
+}

--- a/4-resize-observer/begin/index.html
+++ b/4-resize-observer/begin/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Frontend System Design Fundamentals</title>
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            height: 100vh
+        }
+        #container {
+            margin: 0 auto;
+            width: 600px;
+            display:grid;
+            grid-template-columns: 50% 50%;
+            grid-row-gap: 2rem;
+            grid-column-gap: 2rem;
+        }
+        .box {
+            margin: 2rem;
+            width: 100%;
+            min-width: 100px;
+            min-height: 100px;
+            height: 100%;
+            border: 2px solid black;
+            resize: both;
+            overflow: hidden;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+        }
+        .box:nth-child(1) {
+            background: rgba(0, 255, 0, 0.5);
+        }
+        .box:nth-child(2) {
+            background: rgba(255, 255, 0, 0.5);
+        }
+        .box:nth-child(3) {
+            background: rgba(255, 0, 0, 0.5);
+        }
+        .box:nth-child(4) {
+            background: rgba(0, 0, 255, 0.5);
+        }
+    </style>
+</head>
+<body>
+<main id="container">
+    <div class="box">
+        A
+    </div>
+    <div class="box">
+        B
+    </div>
+    <div class="box">
+        C
+    </div>
+    <div class="box">
+        D
+    </div>
+</main>
+<script type="module">
+    /*
+     * 1. Initiate Resize observer
+     * 2. Implement callback - use inlineSize and blockSize of the entries for width and height
+     * 3. If width and height is less than 150px
+     *   3.1 - Apply border-radius: 100%
+     *   3.2 - Apply border-width: 4px
+     * 4. If width and height is more than 150px = unset the properties above
+     * 5. All 4 boxes should use same observer
+     */
+</script>
+</body>
+</html>

--- a/4-resize-observer/begin/index.html
+++ b/4-resize-observer/begin/index.html
@@ -71,6 +71,25 @@
      * 4. If width and height is more than 150px = unset the properties above
      * 5. All 4 boxes should use same observer
      */
+
+    const observer = new ResizeObserver(entries => {
+        for (const entry of entries) {
+            const target = entry.target;
+            const box = entry.borderBoxSize[0];
+            const [width, height] = [box.inlineSize, box.blockSize];
+            if (width < 150 && height < 150) {
+                target.style.borderRadius = "100%";
+                target.style.border = "4px";
+            } else {
+                target.style.borderRadius = "unset";
+                target.style.border = "unset";
+            }
+        }
+    })
+    const boxes = document.querySelectorAll(".box");
+    boxes.forEach(box => {
+        observer.observe(box);
+    })
 </script>
 </body>
 </html>


### PR DESCRIPTION
This pull request introduces two key features: a Mutation Observer implementation to dynamically update editable headings and an initial setup for a Resize Observer to adjust box styles based on dimensions. The changes are organized into two themes: Mutation Observer functionality and Resize Observer setup.

### Mutation Observer Functionality:
* Added a Mutation Observer in `3-mutation-observer/end/index.html` to monitor changes in editable content and replace text with appropriate heading elements (`h1`, `h2`, `h3`) based on predefined rules.
* Implemented utility functions in `3-mutation-observer/end/utils.js`:
  - [`createCardElement`](diffhunk://#diff-7fb45d3b27a385614ed22829503773896965145fbdb575b7374d13d9360c2a17R1-R23): Generates card elements using a template for dynamic content rendering.
  - [`getHeading`](diffhunk://#diff-7fb45d3b27a385614ed22829503773896965145fbdb575b7374d13d9360c2a17R1-R23): Converts text nodes into editable heading elements (`h1`, `h2`, `h3`) based on specific prefixes.

### Resize Observer Setup:
* Added a basic implementation of Resize Observer in `4-resize-observer/begin/index.html` to monitor box dimensions and apply styling changes (e.g., border-radius and border-width) when dimensions fall below or exceed a threshold.